### PR TITLE
fix  a NSString type-defect

### DIFF
--- a/BFColorPickerPopover Demo.xcodeproj/project.pbxproj
+++ b/BFColorPickerPopover Demo.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Demo/BFColorPickerPopover Demo-Prefix.pch";
 				INFOPLIST_FILE = "Demo/BFColorPickerPopover Demo-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "BFColorPickerPopover Demo";
 				WRAPPER_EXTENSION = app;
 			};
@@ -450,6 +451,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Demo/BFColorPickerPopover Demo-Prefix.pch";
 				INFOPLIST_FILE = "Demo/BFColorPickerPopover Demo-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "BFColorPickerPopover Demo";
 				WRAPPER_EXTENSION = app;
 			};

--- a/BFColorPickerPopover/Helper Classes/BFIconTabBar.h
+++ b/BFColorPickerPopover/Helper Classes/BFIconTabBar.h
@@ -67,7 +67,7 @@
 @interface BFIconTabBarItem : NSObject
 
 @property (nonatomic, strong) NSImage *icon;
-@property (nonatomic, copy) NSString *tooltip;
+@property (nonatomic, strong) NSString *tooltip;
 @property (nonatomic, unsafe_unretained) BFIconTabBar *tabBar;
 
 - (id)initWithIcon:(NSImage *)image tooltip:(NSString *)tooltipString;


### PR DESCRIPTION
While I try the Demo on **Lion 10.7.4** and **Xcode 4.6.3 (4H1503)** , the **copy** declared of the tooltip property in `BFIconTabBar.h`  cause the following  problem:

![8c3b5678-b20c-4118-ae40-674c652939a9](https://f.cloud.github.com/assets/2641747/2427439/a2d79148-abe8-11e3-8fe4-4144d54ac9f3.png)
